### PR TITLE
feat: use the rembg which is not using numba since it takes too much …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ qrcode[pil]
 onnxruntime-gpu
 requirements-parser
 # opencv-contrib
-rembg
+# Replace rembg with fork that removes numba dependency
+git+https://github.com/gazai-io/rembg.git@feat/remove-numba-for-serverless
 imageio_ffmpeg
 rich
 rich_argparse


### PR DESCRIPTION
Since Numba takes too much time to compile in a serverless environment, use the customized version of rembg from which Numba has been removed.